### PR TITLE
chore: update user-agent pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2025-09-18
+
+### Changed
+- Update the default `User-Agent` header sent by `ClixAPIClient` to match the conventions used by our other SDKs.
+
 ## [0.0.1] - 2025-06-01
 
 ### Added

--- a/lib/src/services/clix_api_client.dart
+++ b/lib/src/services/clix_api_client.dart
@@ -21,7 +21,7 @@ class ClixAPIClient {
       'Content-Type': 'application/json',
       'X-Clix-Project-ID': _config.projectId,
       'X-Clix-API-Key': _config.apiKey,
-      'User-Agent': 'Clix-Flutter-SDK/$version',
+      'User-Agent': 'clix-flutter-sdk/$version',
     };
 
     if (_config.extraHeaders != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: clix_flutter
 description: Clix - Clix - Mobile push for builders
 
-version: 0.0.1
+version: 0.0.2
 homepage: https://clix.so
 repository: https://github.com/clix-so/clix-flutter-sdk
 


### PR DESCRIPTION
* Update the default `User-Agent` header sent by `ClixAPIClient` to match the conventions used by our other SDKs.