### PR TITLE
feat: add session tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2026-02-12
+
+### Added
+
+- Session tracking with automatic SESSION_START lifecycle events
+
 ## [0.0.3] - 2025-12-01
 
 ### Added

--- a/lib/src/core/clix.dart
+++ b/lib/src/core/clix.dart
@@ -6,6 +6,7 @@ import '../services/device_service.dart';
 import '../services/event_api_service.dart';
 import '../services/event_service.dart';
 import '../services/notification_service.dart';
+import '../services/session_service.dart';
 import '../services/storage_service.dart';
 import '../services/token_service.dart';
 import '../utils/clix_error.dart';
@@ -31,6 +32,7 @@ class Clix {
   StorageService? _storageService;
   EventService? _eventService;
   DeviceService? _deviceService;
+  SessionService? _sessionService;
   NotificationService? _notificationService;
 
   Clix._();
@@ -101,6 +103,13 @@ class Clix {
       deviceService: _deviceService!,
     );
 
+    // Initialize session service
+    _sessionService = SessionService(
+      storageService: _storageService!,
+      eventService: _eventService!,
+      sessionTimeoutMs: config.sessionTimeoutMs,
+    );
+
     // Initialize notification service
     _notificationService = NotificationService();
     await _notificationService!.initialize(
@@ -108,7 +117,11 @@ class Clix {
       storageService: _storageService!,
       deviceService: _deviceService!,
       tokenService: tokenService,
+      sessionService: _sessionService,
     );
+
+    // Start session (after notification service so initial notification can set pendingMessageId)
+    await _sessionService!.start();
   }
 
   /// Wait for initialization with timeout protection

--- a/lib/src/core/clix_config.dart
+++ b/lib/src/core/clix_config.dart
@@ -10,6 +10,7 @@ class ClixConfig {
   final String endpoint;
   final ClixLogLevel logLevel;
   final Map<String, String>? extraHeaders;
+  final int sessionTimeoutMs;
 
   const ClixConfig({
     required this.projectId,
@@ -17,6 +18,7 @@ class ClixConfig {
     this.endpoint = 'https://api.clix.so',
     this.logLevel = ClixLogLevel.error,
     this.extraHeaders,
+    this.sessionTimeoutMs = 30000,
   });
 
   Map<String, dynamic> toJson() => _$ClixConfigToJson(this);

--- a/lib/src/core/clix_config.g.dart
+++ b/lib/src/core/clix_config.g.dart
@@ -15,6 +15,7 @@ ClixConfig _$ClixConfigFromJson(Map json) => ClixConfig(
       extraHeaders: (json['extra_headers'] as Map?)?.map(
         (k, e) => MapEntry(k as String, e as String),
       ),
+      sessionTimeoutMs: (json['session_timeout_ms'] as num?)?.toInt() ?? 30000,
     );
 
 Map<String, dynamic> _$ClixConfigToJson(ClixConfig instance) =>
@@ -24,6 +25,7 @@ Map<String, dynamic> _$ClixConfigToJson(ClixConfig instance) =>
       'endpoint': instance.endpoint,
       'log_level': _$ClixLogLevelEnumMap[instance.logLevel]!,
       'extra_headers': instance.extraHeaders,
+      'session_timeout_ms': instance.sessionTimeoutMs,
     };
 
 const _$ClixLogLevelEnumMap = {

--- a/lib/src/services/notification_service.dart
+++ b/lib/src/services/notification_service.dart
@@ -73,7 +73,7 @@ class NotificationService {
       ClixLogger.info('Initializing notification service');
 
       await _initializeLocalNotifications();
-      _setupMessageHandlers();
+      await _setupMessageHandlers();
       await _getAndUpdateTokenIfPermitted();
       _firebaseMessaging.onTokenRefresh.listen(_onTokenRefresh);
 
@@ -173,11 +173,11 @@ class NotificationService {
     return settings;
   }
 
-  void _setupMessageHandlers() {
+  Future<void> _setupMessageHandlers() async {
     FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
     FirebaseMessaging.onMessage.listen(_onForegroundMessage);
     FirebaseMessaging.onMessageOpenedApp.listen(_onMessageOpenedApp);
-    _handleInitialMessage();
+    await _handleInitialMessage();
   }
 
   Future<void> _onForegroundMessage(RemoteMessage message) async {

--- a/lib/src/services/notification_service.dart
+++ b/lib/src/services/notification_service.dart
@@ -17,6 +17,7 @@ import '../services/event_api_service.dart';
 import '../utils/logging/clix_logger.dart';
 import 'device_service.dart';
 import 'event_service.dart';
+import 'session_service.dart';
 import 'storage_service.dart';
 import 'token_service.dart';
 
@@ -41,6 +42,7 @@ class NotificationService {
   StorageService? _storageService;
   DeviceService? _deviceService;
   TokenService? _tokenService;
+  SessionService? _sessionService;
 
   bool _isInitialized = false;
   String? _currentToken;
@@ -53,6 +55,7 @@ class NotificationService {
     required StorageService storageService,
     DeviceService? deviceService,
     TokenService? tokenService,
+    SessionService? sessionService,
     Function(Map<String, dynamic>)? onPushReceived,
     Function(Map<String, dynamic>)? onPushTapped,
   }) async {
@@ -62,6 +65,7 @@ class NotificationService {
     _storageService = storageService;
     _deviceService = deviceService;
     _tokenService = tokenService;
+    _sessionService = sessionService;
     this.onPushReceived = onPushReceived;
     this.onPushTapped = onPushTapped;
 
@@ -343,6 +347,8 @@ class NotificationService {
     try {
       final clixPayload = parseClixPayload(userInfo);
       if (clixPayload != null) {
+        final messageId = clixPayload['message_id'] as String?;
+        _sessionService?.setPendingMessageId(messageId);
         await _trackPushEvent('PUSH_NOTIFICATION_TAPPED', clixPayload);
       }
       onPushTapped?.call(userInfo);

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -26,8 +26,7 @@ class SessionService with WidgetsBindingObserver {
     required int sessionTimeoutMs,
   })  : _storageService = storageService,
         _eventService = eventService,
-        _effectiveTimeoutMs =
-            sessionTimeoutMs < 5000 ? 5000 : sessionTimeoutMs;
+        _effectiveTimeoutMs = sessionTimeoutMs < 5000 ? 5000 : sessionTimeoutMs;
 
   Future<void> start() async {
     WidgetsBinding.instance.addObserver(this);

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -58,23 +58,31 @@ class SessionService with WidgetsBindingObserver {
   }
 
   Future<void> _onResumed() async {
-    // Small delay to allow notification tap handlers to set pendingMessageId
-    await Future.delayed(const Duration(milliseconds: 100));
+    try {
+      // Small delay to allow notification tap handlers to set pendingMessageId
+      await Future.delayed(const Duration(milliseconds: 100));
 
-    final lastActivity = await _storageService.get<int>(_lastActivityKey);
-    if (lastActivity != null) {
-      final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
-      if (elapsed <= _effectiveTimeoutMs) {
-        _pendingMessageId = null;
-        await _updateLastActivity();
-        return;
+      final lastActivity = await _storageService.get<int>(_lastActivityKey);
+      if (lastActivity != null) {
+        final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
+        if (elapsed <= _effectiveTimeoutMs) {
+          _pendingMessageId = null;
+          await _updateLastActivity();
+          return;
+        }
       }
+      await _startNewSession();
+    } catch (e) {
+      ClixLogger.error('Failed to handle app resumed', e);
     }
-    await _startNewSession();
   }
 
   Future<void> _onPaused() async {
-    await _updateLastActivity();
+    try {
+      await _updateLastActivity();
+    } catch (e) {
+      ClixLogger.error('Failed to handle app paused', e);
+    }
   }
 
   Future<void> _startNewSession() async {

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -35,6 +35,7 @@ class SessionService with WidgetsBindingObserver {
     if (lastActivity != null) {
       final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
       if (elapsed <= _effectiveTimeoutMs) {
+        _pendingMessageId = null;
         await _updateLastActivity();
         ClixLogger.debug('Continuing existing session');
         return;
@@ -64,6 +65,7 @@ class SessionService with WidgetsBindingObserver {
     if (lastActivity != null) {
       final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
       if (elapsed <= _effectiveTimeoutMs) {
+        _pendingMessageId = null;
         await _updateLastActivity();
         return;
       }

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -31,17 +31,21 @@ class SessionService with WidgetsBindingObserver {
   Future<void> start() async {
     WidgetsBinding.instance.addObserver(this);
 
-    final lastActivity = await _storageService.get<int>(_lastActivityKey);
-    if (lastActivity != null) {
-      final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
-      if (elapsed <= _effectiveTimeoutMs) {
-        _pendingMessageId = null;
-        await _updateLastActivity();
-        ClixLogger.debug('Continuing existing session');
-        return;
+    try {
+      final lastActivity = await _storageService.get<int>(_lastActivityKey);
+      if (lastActivity != null) {
+        final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
+        if (elapsed <= _effectiveTimeoutMs) {
+          _pendingMessageId = null;
+          await _updateLastActivity();
+          ClixLogger.debug('Continuing existing session');
+          return;
+        }
       }
+      await _startNewSession();
+    } catch (e) {
+      ClixLogger.error('Failed to start session', e);
     }
-    await _startNewSession();
   }
 
   @override

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -101,6 +101,10 @@ class SessionService with WidgetsBindingObserver {
     }
   }
 
+  void cleanup() {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
   Future<void> _updateLastActivity() async {
     await _storageService.set<int>(
         _lastActivityKey, DateTime.now().millisecondsSinceEpoch);

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/widgets.dart';
+
+import '../utils/logging/clix_logger.dart';
+import 'event_service.dart';
+import 'storage_service.dart';
+
+enum SessionEvent {
+  sessionStart('SESSION_START');
+
+  final String value;
+  const SessionEvent(this.value);
+}
+
+class SessionService with WidgetsBindingObserver {
+  static const String _lastActivityKey = 'clix_session_last_activity';
+
+  final StorageService _storageService;
+  final EventService _eventService;
+  final int _effectiveTimeoutMs;
+
+  String? _pendingMessageId;
+
+  SessionService({
+    required StorageService storageService,
+    required EventService eventService,
+    required int sessionTimeoutMs,
+  })  : _storageService = storageService,
+        _eventService = eventService,
+        _effectiveTimeoutMs =
+            sessionTimeoutMs < 5000 ? 5000 : sessionTimeoutMs;
+
+  Future<void> start() async {
+    WidgetsBinding.instance.addObserver(this);
+
+    final lastActivity = await _storageService.get<int>(_lastActivityKey);
+    if (lastActivity != null) {
+      final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
+      if (elapsed <= _effectiveTimeoutMs) {
+        await _updateLastActivity();
+        ClixLogger.debug('Continuing existing session');
+        return;
+      }
+    }
+    await _startNewSession();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _onResumed();
+    } else if (state == AppLifecycleState.paused) {
+      _onPaused();
+    }
+  }
+
+  void setPendingMessageId(String? messageId) {
+    _pendingMessageId = messageId;
+  }
+
+  Future<void> _onResumed() async {
+    // Small delay to allow notification tap handlers to set pendingMessageId
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    final lastActivity = await _storageService.get<int>(_lastActivityKey);
+    if (lastActivity != null) {
+      final elapsed = DateTime.now().millisecondsSinceEpoch - lastActivity;
+      if (elapsed <= _effectiveTimeoutMs) {
+        await _updateLastActivity();
+        return;
+      }
+    }
+    await _startNewSession();
+  }
+
+  Future<void> _onPaused() async {
+    await _updateLastActivity();
+  }
+
+  Future<void> _startNewSession() async {
+    final messageId = _pendingMessageId;
+    _pendingMessageId = null;
+    await _updateLastActivity();
+
+    try {
+      await _eventService.trackEvent(
+        SessionEvent.sessionStart.value,
+        messageId: messageId,
+      );
+      ClixLogger.debug('${SessionEvent.sessionStart.value} tracked');
+    } catch (e) {
+      ClixLogger.error('Failed to track ${SessionEvent.sessionStart.value}', e);
+    }
+  }
+
+  Future<void> _updateLastActivity() async {
+    await _storageService.set<int>(
+        _lastActivityKey, DateTime.now().millisecondsSinceEpoch);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: clix_flutter
 description: Clix - Clix - Mobile push for builders
 
-version: 0.0.3
+version: 0.0.4
 homepage: https://clix.so
 repository: https://github.com/clix-so/clix-flutter-sdk
 


### PR DESCRIPTION
### Summary
- Add session tracking to the Flutter SDK
- `SessionService` tracks `SESSION_START` events using `WidgetsBindingObserver` for lifecycle detection (`resumed`/`paused`)
- Timeout-based session management with configurable `sessionTimeoutMs` (default 30s, minimum 5s enforced)
- Push notification tap attributes session via `pendingMessageId` through `NotificationService`
- Add `sessionTimeoutMs` to `ClixConfig`

### Changes
- **New:** `lib/src/services/session_service.dart` — `SessionService` with `WidgetsBindingObserver`, `SessionEvent` enum
- **Modified:** `lib/src/core/clix.dart` — Initialize and start `SessionService` after `NotificationService`
- **Modified:** `lib/src/core/clix_config.dart` / `.g.dart` — Add `sessionTimeoutMs` field (default 30000)
- **Modified:** `lib/src/services/notification_service.dart` — Set `pendingMessageId` on push tap for session attribution

### Spec
- https://www.notion.so/greyboxhq/Tech-Clix-Session-3031f02665f180dfa04bc91a836f0889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session management to monitor user activity and maintain session continuity.
  * Session timeout is now configurable (default: 30 seconds).
  * Notifications now propagate message IDs to session tracking so session starts include relevant notification context.
* **Documentation**
  * Changelog updated and package version bumped for the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->