### PR TITLE
feat: add sourceType to event tracking

### DIFF
--- a/lib/src/services/event_api_service.dart
+++ b/lib/src/services/event_api_service.dart
@@ -11,6 +11,7 @@ class EventAPIService {
     required String name,
     required Map<String, dynamic> properties,
     String? messageId,
+    String? sourceType,
   }) async {
     try {
       ClixLogger.debug('Tracking event: $name for device: $deviceId');
@@ -18,6 +19,7 @@ class EventAPIService {
       final eventRequestBody = {
         'device_id': deviceId,
         'name': name,
+        if (sourceType != null) 'source_type': sourceType,
         'event_property': {
           'custom_properties': properties,
           if (messageId != null) 'message_id': messageId,

--- a/lib/src/services/event_service.dart
+++ b/lib/src/services/event_service.dart
@@ -16,6 +16,7 @@ class EventService {
     String name, {
     Map<String, dynamic>? properties,
     String? messageId,
+    String? sourceType,
   }) async {
     try {
       ClixLogger.debug('Tracking event: $name');
@@ -35,6 +36,7 @@ class EventService {
         deviceId: deviceId,
         name: name,
         properties: cleanProperties,
+        sourceType: sourceType,
         messageId: messageId,
       );
 

--- a/lib/src/services/notification_service.dart
+++ b/lib/src/services/notification_service.dart
@@ -597,6 +597,7 @@ class NotificationService {
 
     await _eventService?.trackEvent(
       eventType,
+      sourceType: 'CLIX',
       properties: properties,
       messageId: messageId,
     );
@@ -665,6 +666,7 @@ class NotificationService {
 
       await eventService.trackEvent(
         'PUSH_NOTIFICATION_RECEIVED',
+        sourceType: 'CLIX',
         properties: properties,
         messageId: messageId,
       );
@@ -841,6 +843,7 @@ Future<void> _trackPushNotificationReceivedInBackground(
 
     await eventService.trackEvent(
       'PUSH_NOTIFICATION_RECEIVED',
+      sourceType: 'CLIX',
       properties: properties,
       messageId: messageId,
     );

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -97,6 +97,7 @@ class SessionService with WidgetsBindingObserver {
     try {
       await _eventService.trackEvent(
         SessionEvent.sessionStart.value,
+        sourceType: 'CLIX',
         messageId: messageId,
       );
       ClixLogger.debug('${SessionEvent.sessionStart.value} tracked');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: clix_flutter
 description: Clix - Clix - Mobile push for builders
 
-version: 0.0.4
+version: 0.0.5
 homepage: https://clix.so
 repository: https://github.com/clix-so/clix-flutter-sdk
 


### PR DESCRIPTION
## Summary
- SESSION_START, PUSH_NOTIFICATION_RECEIVED, PUSH_NOTIFICATION_TAPPED 이벤트에 `sourceType: "CLIX"` 추가
- EventService, EventAPIService에 `sourceType` 파라미터 추가 (기본값 null, 브레이킹 체인지 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event tracking now supports an optional sourceType field; tracking calls from notifications and new sessions include sourceType set to "CLIX".
* **Chore**
  * Package version updated (0.0.4 → 0.0.5).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->