### PR TITLE
feat: add reset() and deprecate removeUserId()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-02-19
+
+### Added
+
+- `reset()` method to clear all local SDK state including device ID
+
+### Changed
+
+- `setUserId()` now accepts null to remove the user ID
+
+### Deprecated
+
+- `removeUserId()` — use `setUserId(null)` instead
+
 ## [0.0.5] - 2026-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `reset()` method to clear all local SDK state including device ID
 
-### Changed
-
-- `setUserId()` now accepts null to remove the user ID
-
 ### Deprecated
 
-- `removeUserId()` — use `setUserId(null)` instead
+- `removeUserId()` — use `reset()` instead
 
 ## [0.0.5] - 2026-02-13
 

--- a/lib/src/core/clix.dart
+++ b/lib/src/core/clix.dart
@@ -162,6 +162,8 @@ class Clix {
   static Future<void> reset() async {
     await _waitForInitialization();
     try {
+      _shared!._sessionService?.cleanup();
+      await _shared!._notificationService?.reset();
       await _shared!._storageService?.remove('clix_device_id');
       await _shared!._storageService?.remove('clix_session_last_activity');
       _shared = null;

--- a/lib/src/core/clix.dart
+++ b/lib/src/core/clix.dart
@@ -26,7 +26,7 @@ class Clix {
 
   static Clix? _shared;
   static bool _isInitializing = false;
-  static final _initCompleter = Completer<void>();
+  static Completer<void> _initCompleter = Completer<void>();
 
   // Services - nullable until initialization
   StorageService? _storageService;
@@ -145,12 +145,30 @@ class Clix {
   }
 
   /// Remove user ID
+  @Deprecated('Use reset() instead')
   static Future<void> removeUserId() async {
     await _waitForInitialization();
     try {
       await _shared!._deviceService!.removeProjectUserId();
     } catch (e) {
       throw ClixError.unknownErrorWithReason('Failed to remove user ID: $e');
+    }
+  }
+
+  /// Resets all local SDK state including device ID.
+  ///
+  /// After calling this method, you must call [initialize] again before using the SDK.
+  /// Use this when a user logs out and you want to start fresh with a new device identity.
+  static Future<void> reset() async {
+    await _waitForInitialization();
+    try {
+      await _shared!._storageService?.remove('clix_device_id');
+      await _shared!._storageService?.remove('clix_session_last_activity');
+      _shared = null;
+      _isInitializing = false;
+      _initCompleter = Completer<void>();
+    } catch (e) {
+      throw ClixError.unknownErrorWithReason('Failed to reset: $e');
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: clix_flutter
 description: Clix - Clix - Mobile push for builders
 
-version: 0.0.5
+version: 0.1.0
 homepage: https://clix.so
 repository: https://github.com/clix-so/clix-flutter-sdk
 


### PR DESCRIPTION
## Summary
Add `reset()` method for logout support and deprecate `removeUserId()`.

## Changes
- Add `reset()` method that clears all local SDK state (device ID, session) without server calls
- Deprecate `removeUserId()` — use `reset()` instead
- Bump version to 0.1.0

## Spec
https://docs.google.com/document/d/1ET-KqAFQlODNEm08YDXehzfWuqKZsOhnr4NJG-f0P9k/edit?tab=t.0#bookmark=id.9awmqjhnpii6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reset() to clear all local SDK state, including device ID. SDK will reinitialize after reset.

* **Changed**
  * Package version updated to 0.1.0.

* **Deprecated**
  * removeUserId() is deprecated; use reset() instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->