### PR TITLE
docs: sync README with latest SDK API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  clix_flutter: ^0.0.3
+  clix_flutter: ^0.1.0
 ```
 
 Then run:
@@ -74,10 +74,17 @@ await Clix.setUserProperties({
 // Remove user properties
 await Clix.removeUserProperty('name');
 await Clix.removeUserProperties(['age', 'premium']);
-
-// Remove user ID
-await Clix.removeUserId();
 ```
+
+### Reset
+
+Use `reset()` when you need a completely fresh device identity (e.g., shared device scenarios). This clears all local SDK state and generates a new device ID on next initialization.
+
+```dart
+await Clix.reset();
+```
+
+> **Note:** After calling `reset()`, you must call `initialize()` again before using the SDK.
 
 ### Event Tracking
 


### PR DESCRIPTION
## 배경

`reset()` API 추가 및 `removeUserId()` deprecated에 따라 README를 최신 SDK API에 맞게 동기화합니다.

## 변경 사항

### Installation
- 의존성 버전 0.0.3 → 0.1.0으로 업데이트 (최신 릴리즈 반영)

### User Management
- deprecated된 `removeUserId()` 예제를 User Management 섹션에서 제거

### Reset 섹션 추가
- `Clix.reset()` 사용법과 설명 추가 (새 device ID 생성, user ID 제거, session 데이터 초기화)
- `reset()` 호출 후 반드시 `initialize()`를 다시 호출해야 한다는 안내 포함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `Clix.reset()` method to clear local state and generate a new device ID.
  * `initialize()` must be called again after reset before resuming SDK usage.

* **Documentation**
  * Updated examples with new Reset workflow in User Management.
  * Bumped clix_flutter dependency to ^0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->